### PR TITLE
Fix default cloned branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This repo hosts the Vim/Neovim color scheme.
 
 Install the plugin with whatever plugin manager you use:
 
-`Plug 'pineapplegiant/spaceduck'`
+`Plug 'pineapplegiant/spaceduck', { 'branch': 'main' }`
 
 And add this to your vimrc/init.vim configuration file:
 


### PR DESCRIPTION
For using vim-plug the default branch is `master` so this PR updates the README to remind the user that the branch `main` needs to be specified