### PR TITLE
Add light theme

### DIFF
--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -23,7 +23,31 @@ let g:colors_name="spaceduck"
 
 " Spaceduck Color Variables {{{
 " dark theme and light theme settings
-" TODO light theme isn't done yet
+let s:palette = {
+      \ 'red':          ['#e33400', '166'],
+      \ 'orange':       ['#e39400', '172'],
+      \ 'green':        ['#5ccc96', '78'],
+      \ 'yellow':       ['#f2ce00', '220'],
+      \ 'lavender':     ['#b3a1e6', '146'],
+      \ 'grape':        ['#7a5ccc', '98'],
+      \ 'space':        ['#30365F', '237'],
+      \ 'blueberry':    ['#686f9a', '60'],
+      \ 'cyan':         ['#00a3cc', '38'],
+      \ 'magenta':      ['#ce6f8f', '168'],
+      \
+      \ 'deep_space':   ['#0f111b', '233'],
+      \ 'cream':        ['#ecf0c1', '255'],
+      \ 'vision':       ['#1b1c36', '234'],
+      \ 'cursor':       ['#16172d', '234'],
+      \ 
+      \ 'grey':         ['#818596', '102'],
+      \ 'light_grey':   ['#818596', '102'],
+      \ 'white':        ['#ffffff', '15'],
+      \ 'black':        ['#000000', '0'],
+      \
+      \ 'none':         ['NONE',    'NONE']
+      \ }
+
 if &background == 'dark'
   hi SpaceduckRed guifg=#e33400 ctermfg=166 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
   hi SpaceduckOrange guifg=#e39400 ctermfg=172 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
@@ -37,11 +61,47 @@ if &background == 'dark'
   hi SpaceduckMagenta guifg=#ce6f8f ctermfg=168 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
   hi SpaceduckForeground guifg=#ecf0c1 ctermfg=255 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+
+  let s:palette.bg = s:palette.deep_space
+  let s:palette.fg = s:palette.cream
+
+elseif &background == 'light'
+  hi SpaceduckRed guifg=#e33400 ctermfg=166 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckOrange guifg=#e39400 ctermfg=172 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckGreen guifg=#5ccc96 ctermfg=78 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckYellow guifg=#f2ce00 ctermfg=220 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckPurple guifg=#b3a1e6 ctermfg=237 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckPurple2 guifg=#7a5ccc ctermfg=98 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckDarkPurple guifg=#30365F ctermfg=237 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckDarkPurple2 guifg=#686f9a ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckCyan guifg=#59c2ff ctermfg=38 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+  hi SpaceduckMagenta guifg=#ce6f8f ctermfg=168 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+
+  hi SpaceduckForeground guifg=#ecf0c1 ctermfg=255 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+
+  let s:palette.bg = s:palette.cream
+  let s:palette.fg = s:palette.deep_space
+
 endif
+" }}}
+"
+" Highlight function {{{
+function! s:hi(group, fg, bg, ...)
+  let hl_string = [
+      \ 'highlight', a:group,
+      \ 'guifg=' . a:fg[0],
+      \ 'guibg=' . a:bg[0],
+      \ 'ctermfg=' . a:fg[1],
+      \ 'ctermbg=' . a:bg[1],
+      \ ]
+
+  execute join(hl_string, ' ')
+endfunction
 " }}}
 
 " Syntax Highlighting {{{
-hi Normal guifg=#ecf0c1 ctermfg=255 guibg=#0f111b ctermbg=233 gui=NONE cterm=NONE
+call s:hi('Normal', s:palette.fg, s:palette.bg)
+
 hi! link Boolean SpaceduckYellow
 hi! link Character SpaceduckYellow
 hi ColorColumn guifg=NONE ctermfg=NONE guibg=#16172d ctermbg=234 gui=NONE cterm=NONE

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -37,8 +37,8 @@ let s:palette = {
       \
       \ 'deep_space':   ['#0f111b', '233'],
       \ 'cream':        ['#ecf0c1', '255'],
-      \ 'vision':       ['#1b1c36', '234'],
-      \ 'cursor':       ['#16172d', '234'],
+      \ 'selection':    ['#30365F', '237'],
+      \ 'cursor':       ['#1b1c36', '234'],
       \ 
       \ 'grey':         ['#818596', '102'],
       \ 'light_grey':   ['#818596', '102'],
@@ -64,8 +64,10 @@ if &background == 'dark'
 
   let s:palette.bg = s:palette.deep_space
   let s:palette.fg = s:palette.cream
+endif
 
-elseif &background == 'light'
+" I don't want anyone accidentally stumbling on this just yet
+if exists('g:spaceduck_dev_light_theme')
   hi SpaceduckRed guifg=#e33400 ctermfg=166 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
   hi SpaceduckOrange guifg=#e39400 ctermfg=172 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
   hi SpaceduckGreen guifg=#5ccc96 ctermfg=78 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
@@ -79,12 +81,12 @@ elseif &background == 'light'
 
   hi SpaceduckForeground guifg=#ecf0c1 ctermfg=255 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 
-  let s:palette.bg = s:palette.cream
+  let s:palette.bg = s:palette.white
   let s:palette.fg = s:palette.deep_space
 
 endif
 " }}}
-"
+
 " Highlight function {{{
 function! s:hi(group, fg, bg, ...)
   let hl_string = [
@@ -93,6 +95,8 @@ function! s:hi(group, fg, bg, ...)
       \ 'guibg=' . a:bg[0],
       \ 'ctermfg=' . a:fg[1],
       \ 'ctermbg=' . a:bg[1],
+      \ 'gui=' . (a:0 >= 1 ? a:1 : 'NONE'),
+      \ 'cterm=' . (a:0 >= 1 ? a:1 : 'NONE')
       \ ]
 
   execute join(hl_string, ' ')
@@ -110,7 +114,7 @@ hi! link Conceal SpaceduckDarkPurple2
 hi! link Conditional SpaceduckGreen
 hi! link Constant SpaceduckYellow
 hi Cursor guifg=#0f111b ctermfg=233 guibg=#818596 ctermbg=102 gui=NONE cterm=NONE
-hi CursorLine guifg=NONE ctermfg=NONE guibg=#1b1c36 ctermbg=234 gui=NONE cterm=NONE
+call s:hi('CursorLine', s:palette.none, s:palette.cursor)
 hi CursorLineNr guifg=#c1c3cc ctermfg=251 guibg=#16172d ctermbg=234 gui=NONE cterm=NONE
 hi! link Debug SpaceduckPurple
 hi! link Define SpaceduckPurple2


### PR DESCRIPTION
This PR is an attempt to fix #24.

To easily toggle between the light/dark background I believe we need to rewrite the `colors/spaceduck.vim` file and change its structure. For now I only included an example of how I intend to do it. I believe we'll need to remove `hi Spaceduck` statements in the `&background` if blocks since they won't be needed anymore once we start using the palette dictionary. I added a custom function to keep the `highlight` call DRY. I also just changed the `hi Normal` call to showcase the function use case.