### PR TITLE
feat: Add specific markdown syntax highlighting

### DIFF
--- a/after/syntax/markdown.vim
+++ b/after/syntax/markdown.vim
@@ -1,0 +1,53 @@
+if spaceduck#should_abort('markdown', 'mkd')
+    finish
+endif
+
+syn match markdownBlockquote ">\%(\s\|$\).*" contained nextgroup=@markdownBlock
+
+if b:current_syntax ==# 'mkd'
+" plasticboy/vim-markdown {{{1
+  hi! link htmlBold       SpaceduckOrangeBold
+  hi! link htmlBoldItalic SpaceduckOrangeBoldItalic
+  hi! link htmlH1         SpaceduckPurpleBold
+  hi! link htmlItalic     SpaceduckYellowItalic
+  hi! link mkdBlockquote  SpaceduckComment
+  hi! link mkdBold        SpaceduckOrangeBold
+  hi! link mkdBoldItalic  SpaceduckOrangeBoldItalic
+  hi! link mkdCode        SpaceduckGreen
+  hi! link mkdCodeEnd     SpaceduckGreen
+  hi! link mkdCodeStart   SpaceduckGreen
+  hi! link mkdHeading     SpaceduckPurpleBold
+  hi! link mkdInlineUrl   SpaceduckLink
+  hi! link mkdItalic      SpaceduckYellowItalic
+  hi! link mkdLink        SpaceduckGreen
+  hi! link mkdListItem    SpaceduckCyan
+  hi! link mkdRule        SpaceduckComment
+  hi! link mkdUrl         SpaceduckLink
+"}}}1
+elseif b:current_syntax ==# 'markdown'
+" Builtin: {{{1
+  hi! link markdownBlockquote        SpaceduckCommentItalic
+  hi! link markdownBold              SpaceduckYellowBold
+  hi! link markdownBoldItalic        SpaceduckYellowBoldItalic
+  hi! link markdownCodeBlock         SpaceduckPurple
+  hi! link markdownCode              SpaceduckPurple
+  hi! link markdownCodeDelimiter     SpaceduckPurple
+  hi! link markdownH1                SpaceduckPurple2Bold
+  hi! link markdownH2                markdownH1
+  hi! link markdownH3                markdownH1
+  hi! link markdownH4                markdownH1
+  hi! link markdownH5                markdownH1
+  hi! link markdownH6                markdownH1
+  hi! link markdownHeadingDelimiter  markdownH1
+  hi! link markdownHeadingRule       markdownH1
+  hi! link markdownItalic            SpaceduckYellowItalic
+  hi! link markdownLinkText          SpaceduckGreen
+  hi! link markdownListMarker        SpaceduckCyan
+  hi! link markdownOrderedListMarker SpaceduckCyan
+  hi! link markdownRule              SpaceduckComment
+  hi! link markdownUrl               SpaceduckCyan
+"}}}
+endif
+
+" vim: fdm=marker ts=2 sts=2 sw=2 fdl=0:
+

--- a/autoload/spaceduck.vim
+++ b/autoload/spaceduck.vim
@@ -1,0 +1,10 @@
+" Helper function that takes a variadic list of filetypes as args and returns
+" whether or not the execution of the ftplugin should be aborted.
+func! spaceduck#should_abort(...)
+    if ! exists('g:colors_name') || g:colors_name !=# 'spaceduck'
+        return 1
+    elseif a:0 > 0 && (! exists('b:current_syntax') || index(a:000, b:current_syntax) == -1)
+        return 1
+    endif
+    return 0
+endfunction

--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -21,6 +21,68 @@ endif
 let g:colors_name="spaceduck"
 " }}}
 
+" User Configuration: {{{2
+if !exists('g:spaceduck_bold')
+  let g:spaceduck_bold = 1
+endif
+
+if !exists('g:spaceduck_italic')
+  let g:spaceduck_italic = 1
+endif
+
+if !exists('g:spaceduck_underline')
+  let g:spaceduck_underline = 1
+endif
+
+if !exists('g:spaceduck_undercurl')
+  let g:spaceduck_undercurl = g:spaceduck_underline
+endif
+
+if !exists('g:spaceduck_inverse')
+  let g:spaceduck_inverse = 1
+endif
+
+if !exists('g:spaceduck_colorterm')
+  let g:spaceduck_colorterm = 1
+endif
+
+"}}}2
+" Script Helpers: {{{2
+let s:attrs = {
+      \ 'bold': g:spaceduck_bold == 1 ? 'bold' : 0,
+      \ 'italic': g:spaceduck_italic == 1 ? 'italic' : 0,
+      \ 'underline': g:spaceduck_underline == 1 ? 'underline' : 0,
+      \ 'undercurl': g:spaceduck_undercurl == 1 ? 'undercurl' : 0,
+      \ 'inverse': g:spaceduck_inverse == 1 ? 'inverse' : 0,
+      \}
+
+function! s:h(scope, fg, ...) " bg, attr_list, special
+  let l:fg = copy(a:fg)
+  let l:bg = get(a:, 1, ['NONE', 'NONE'])
+
+  let l:attr_list = filter(get(a:, 2, ['NONE']), 'type(v:val) == 1')
+  let l:attrs = len(l:attr_list) > 0 ? join(l:attr_list, ',') : 'NONE'
+
+  " Falls back to coloring foreground group on terminals because
+  " nearly all do not support undercurl
+  let l:special = get(a:, 3, ['NONE', 'NONE'])
+  if l:special[0] !=# 'NONE' && l:fg[0] ==# 'NONE' && !has('gui_running')
+    let l:fg[0] = l:special[0]
+    let l:fg[1] = l:special[1]
+  endif
+
+  let l:hl_string = [
+        \ 'highlight', a:scope,
+        \ 'guifg=' . l:fg[0], 'ctermfg=' . l:fg[1],
+        \ 'guibg=' . l:bg[0], 'ctermbg=' . l:bg[1],
+        \ 'gui=' . l:attrs, 'cterm=' . l:attrs,
+        \ 'guisp=' . l:special[0],
+        \]
+
+  execute join(l:hl_string, ' ')
+endfunction
+"}}}2
+
 " PALETTE: {{{
 let s:palette = {
       \ 'red':          ['#e33400', '166'],
@@ -82,8 +144,32 @@ if &background == 'dark'
   call s:hi('SpaceduckCyan',        s:palette.cyan,        s:palette.none)
   call s:hi('SpaceduckMagenta',     s:palette.magenta,     s:palette.none)
 
+  call s:h('SpaceduckRedBold',         s:palette.red,         s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckOrangeBold',      s:palette.orange,      s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckGreenBold',       s:palette.green,       s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckYellowBold',      s:palette.yellow,      s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckPurpleBold',      s:palette.lavender,    s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckDarkPurpleBold',  s:palette.darkpurple,  s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckPurple2Bold',     s:palette.purple2,     s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckDarkPurple2Bold', s:palette.darkpurple2, s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckCyanBold',        s:palette.cyan,        s:palette.none, [s:attrs.bold])
+  call s:h('SpaceduckMagentaBold',     s:palette.magenta,     s:palette.none, [s:attrs.bold])
+  
+  call s:h('SpaceduckRedItalic',         s:palette.red,         s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckOrangeItalic',      s:palette.orange,      s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckGreenItalic',       s:palette.green,       s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckYellowItalic',      s:palette.yellow,      s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckPurpleItalic',      s:palette.lavender,    s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckDarkPurpleItalic',  s:palette.darkpurple,  s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckPurple2Italic',     s:palette.purple2,     s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckDarkPurple2Italic', s:palette.darkpurple2, s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckCyanItalic',        s:palette.cyan,        s:palette.none, [s:attrs.italic])
+  call s:h('SpaceduckMagentaItalic',     s:palette.magenta,     s:palette.none, [s:attrs.italic])
+
   call s:hi('SpaceduckForeground',  s:palette.cream,       s:palette.none)
   call s:hi('SpaceduckComment',     s:palette.comment,     s:palette.none)
+
+  call s:h('SpaceduckCommentItalic', s:palette.comment, s:palette.none, [s:attrs.italic])
 
   call s:hi('SpaceduckGrey',        s:palette.grey,        s:palette.none)
 
@@ -147,8 +233,8 @@ call s:hi('SpellBad',         s:palette.red,         s:palette.none,       'unde
 call s:hi('SpellLocal',       s:palette.green,       s:palette.none,       'underline')
 call s:hi('SpellRare',        s:palette.yellow,      s:palette.none,       'underline')
 
-call s:hi('StatusLine',       s:palette.selection,   s:palette.fg,         'reverse'  )
-call s:hi('StatusLineNC',     s:palette.bg,          s:palette.fg,         'reverse'  )
+call s:hi('StatusLine',       s:palette.bg,          s:palette.fg,         'reverse'  )
+call s:hi('StatusLineNC',     s:palette.bg,          s:palette.grey,       'reverse'  )
 call s:hi('StatusLineTermNC', s:palette.black,       s:palette.darkpurple, 'reverse'  )
 call s:hi('TabLine',          s:palette.black,       s:palette.grey                   )
 call s:hi('TabLineFill',      s:palette.grey,        s:palette.black                  )


### PR DESCRIPTION
# Info 
see: https://github.com/pineapplegiant/spaceduck/issues/48


# Currently Shipped w/vim

![Screen Shot 2021-06-09 at 5 21 09 PM](https://user-images.githubusercontent.com/9803299/121431204-1b21e800-c947-11eb-8392-ebba9ff91dbd.png)

# After these updates:
![Screen Shot 2021-06-09 at 5 15 01 PM](https://user-images.githubusercontent.com/9803299/121430779-84552b80-c946-11eb-823e-e761fdacc285.png)

---

For reference, the Atom syntax readme highlighted that we had decided on before:

![](https://user-images.githubusercontent.com/9803299/121198737-600f2700-c840-11eb-9556-2f148ede1e42.png)

