### PR TITLE
Fix: Add missing list field selector for terminal_ansi_colors

### DIFF
--- a/colors/spaceduck.vim
+++ b/colors/spaceduck.vim
@@ -714,7 +714,7 @@ else
       \ s:palette['cyan'][0],
       \ s:palette['magenta'][0],
       \ s:palette['purple'][0],
-      \ s:palette['darkpurple'],
+      \ s:palette['darkpurple'][0],
       \ s:palette['darkpurple'][0],
       \ s:palette['red'][0],
       \ s:palette['green'][0],


### PR DESCRIPTION
As is, the `terminal_ansi_colors` definition for vim does not work.
There's just one field selector missing for one color, see commit.